### PR TITLE
Cloning with HTTPS in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ https://arxiv.org/abs/2310.09259
 ### Instructions
 
 ```bash
-git clone git@github.com:IST-DASLab/QUIK.git
+git clone https://github.com/IST-DASLab/QUIK.git
 cd QUIK
 pip install -e .  # or pip install .
 ```


### PR DESCRIPTION
Cloning with SSH [requires](https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-ssh-urls) the user to generate an SSH key.

    SSH URLs provide access to a Git repository via SSH, a secure protocol.
    To use these URLs, you must [generate an SSH keypair](https://help.github.com/articles/generating-an-ssh-key) on your computer and add the public key to your GitHub account.

For accessibility, it's better to give an example of cloning with HTTPS, for it to work out of the box for everyone.