### PR TITLE
Fix wheel building problem

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import sys
 import sysconfig
 
 from setuptools import setup
+from setuptools import setup, find_packages
 import subprocess
 
 try:
@@ -135,6 +136,7 @@ try:
     setup(
         name='quik',
         version=version.__version__,
+        packages=find_packages(exclude=("include", "src", "test")),
         **ext_kwargs,
     )
 finally:


### PR DESCRIPTION
When I used `python setup.py bdist_wheel` to build a quik wheel file and install from this wheel, I got some problem in calling the quik functions:
![image](https://github.com/IST-DASLab/QUIK/assets/19584326/68c34645-e757-48ce-bb6f-224f8664a723)
I found that there is only a dynamic lib without any python code in it.
![image](https://github.com/IST-DASLab/QUIK/assets/19584326/a13ccf50-fbbd-45f3-aca1-befb894d679b)

After this file, the python files are included in the wheel and the function calling is correct for quik installed from wheel.
![image](https://github.com/IST-DASLab/QUIK/assets/19584326/2f602a95-5eed-4c24-9fa1-9b8b9e5f723b)

![image](https://github.com/IST-DASLab/QUIK/assets/19584326/4b48960f-77fe-4b27-acde-86b94392dc12)
